### PR TITLE
Fix utils.js for https connections from URL

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ exports.serverFromURL = function(url) {
   i = null;
   parts.host = parts.host.split(':');
 
-  sagRes = exports.server(parts.host.shift(), parts.host.shift());
+  sagRes = exports.server(parts.host.shift(), parts.host.shift(), parts.protocol == 'https:' ? true : false);
 
   //log the user in (if provided)
   if(parts.auth) {


### PR DESCRIPTION
When using `serverFromURL` with https  connections, make sure to set the '`useSSL`' parameter in the call to `exports.server`.
