### PR TITLE
Fix utils.js for https in serverFromURL

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ exports.serverFromURL = function(url) {
   i = null;
   parts.host = parts.host.split(':');
 
-  sagRes = exports.server(parts.host.shift(), parts.host.shift());
+  sagRes = exports.server(parts.host.shift(), parts.host.shift(), parts.protocol === 'https:');
 
   //log the user in (if provided)
   if(parts.auth) {


### PR DESCRIPTION
Set `useSSL` parameter in `serverFromURL` based on protocol: When using `serverFromURL` with an https URL, make sure to set the '`useSSL`' parameter in the call to `exports.server`.
